### PR TITLE
fix/ 전체 옵션 삭제

### DIFF
--- a/src/components/page/Management/ProductInfo/ProductInfoSearch.vue
+++ b/src/components/page/Management/ProductInfo/ProductInfoSearch.vue
@@ -3,7 +3,7 @@ import { useModalStore } from '../../../../stores/modalState';
 import router from '@/router';
 
 const modalState = useModalStore();
-const searchOption = ref('searchAll');
+const searchOption = ref('searchProduct');
 const searchKeyword = ref('');
 
 
@@ -28,7 +28,6 @@ onMounted(() => {
     <div class="search-box">
         <div class="search-container">        
             <select v-model="searchOption">
-                <option value="searchAll">전체</option>
                 <option value="searchProduct">제품명</option>
                 <option value="searchSupplier">납품업체</option>
             </select>


### PR DESCRIPTION
- product-info
  - ProductInfoSearch: 전체는 mapper상 단순히 전체 컬럼중 하나를 검색하는 것이 아닌 전체 리스트를 불러오는 옵션이라 삭제하였습니다.